### PR TITLE
feat: add an option to configure the compiler used

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,13 @@ If `false`, disable hot module replacement.
 
 You can enable SSR optimazation when specify this option `true`.
 
+### compiler
+
+- type: `function`
+- default: `vue-template-compiler`
+
+You can override the default compiler using this option.
+
 ## Templates
 
 There is vue-cli template using vue-template-loader (Thanks to @Toilal).

--- a/lib/modules/template-compiler.js
+++ b/lib/modules/template-compiler.js
@@ -11,7 +11,7 @@ module.exports = function compile (template, options = {}) {
   const compiled = compileTemplate({
     source: template,
     filename: options.filename,
-    compiler,
+    compiler: options.compiler || compiler,
     transformAssetUrls: options.transformAssetUrls,
     isFunctional: options.functional,
     isProduction: options.isProduction,


### PR DESCRIPTION
In the case of NativeScript-Vue, we need to use a different compiler than the default one.